### PR TITLE
Feature/new enhance resolve

### DIFF
--- a/client/components/Bid.js
+++ b/client/components/Bid.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
-import { acceptBid, updateBid } from "../store/favors";
+import { updateBid } from "../store/favors";
 import { fetchSingleFavor } from "../store/SingleFavor";
 import { Link } from "react-router-dom";
 import useAuth from "./utils/useAuthHook";

--- a/client/components/Bid.js
+++ b/client/components/Bid.js
@@ -19,7 +19,11 @@ const Bid = (props) => {
   const handleAcceptBid = async () => {
     // await dispatch(acceptBid(bid.id, bid.favorId));
     // INSTEAD
-    await dispatch(updateBid(bid, { status: "ACCEPTED" }));
+    if (bid.status === "PENDING") {
+      await dispatch(updateBid(bid, { status: "ACCEPTED" }));
+    } else if (bid.status === "ACCEPTED") {
+      await dispatch(updateBid(bid, { status: "PENDING" }));
+    }
     await dispatch(fetchSingleFavor(bid.favorId));
   };
 

--- a/client/components/Bid.js
+++ b/client/components/Bid.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
-import { acceptBid } from "../store/favors";
+import { acceptBid, updateBid } from "../store/favors";
 import { fetchSingleFavor } from "../store/SingleFavor";
 import { Link } from "react-router-dom";
 import useAuth from "./utils/useAuthHook";
@@ -17,7 +17,9 @@ const Bid = (props) => {
   const canViewChat = isAuthor || isVolunteer;
 
   const handleAcceptBid = async () => {
-    await dispatch(acceptBid(bid.id, bid.favorId));
+    // await dispatch(acceptBid(bid.id, bid.favorId));
+    // INSTEAD
+    await dispatch(updateBid(bid, { status: "ACCEPTED" }));
     await dispatch(fetchSingleFavor(bid.favorId));
   };
 

--- a/client/components/BidsList.js
+++ b/client/components/BidsList.js
@@ -1,0 +1,40 @@
+import React from "react";
+import Bid from "./Bid.js";
+import CreateBid from "./CreateBid";
+
+const BidsList = (props) => {
+  const { CurrentUser, favor, bidState, setBidState } = props;
+
+  return (
+    <div>
+      {CurrentUser.id === favor.authorId ? (
+        favor.bids.map((bid) => {
+          return <Bid key={bid.id} bid={bid} favor={favor} />;
+        })
+      ) : (
+        <div>
+          {favor.bids ? (
+            favor.bids
+              .filter((bid) => bid.volunteer.id === CurrentUser.id)
+              .map((bid) => {
+                return <Bid key={bid.id} bid={bid} favor={favor} />;
+              })
+          ) : (
+            <div></div>
+          )}
+          <button
+            onClick={() => {
+              setBidState(true);
+            }}
+          >
+            Offer help : {favor.title}
+          </button>
+          <br />
+          {bidState ? <CreateBid favor={favor} /> : <div></div>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BidsList;

--- a/client/components/SingleFavorView.js
+++ b/client/components/SingleFavorView.js
@@ -29,6 +29,9 @@ const SingleFavor = (props) => {
       await dispatch(updateFavor(favor.id, { status: "OPEN" }));
       await dispatch(fetchSingleFavor(props.match.params.id));
     } else {
+      // set the bid(s) with "ACCEPTED" status to status "FULFILLED"
+      // and set all of the bids with "PENDING" status to "REJECTED"
+
       await dispatch(updateFavor(favor.id, { status: "CLOSED" }));
       await dispatch(fetchSingleFavor(props.match.params.id));
     }

--- a/client/components/SingleFavorView.js
+++ b/client/components/SingleFavorView.js
@@ -7,6 +7,8 @@ import { fetchSingleFavor } from "../store/SingleFavor.js";
 import { updateFavor, updateBid } from "../store/favors";
 import useAuth from "./utils/useAuthHook.js";
 import useFavor from "./utils/useFavorHook";
+// experimenting with toggle function in its own module:
+import { toggleFavorResolved } from "./utils/toggleFavorStatus";
 
 const SingleFavor = (props) => {
   // will use this id (from URL param, from route rendering the component)
@@ -24,59 +26,13 @@ const SingleFavor = (props) => {
     dispatch(fetchSingleFavor(props.match.params.id));
   }, []);
 
-  const toggleFavorResolved = async () => {
-    if (favor.status === "CLOSED") {
-      if (favor.bids) {
-        let rejectedBids = favor.bids.filter(
-          (bid) => bid.status === "REJECTED"
-        );
-        let fulfilledBids = favor.bids.filter(
-          (bid) => bid.status === "FULFILLED"
-        );
-        await Promise.all(
-          rejectedBids.map((bid) => {
-            return dispatch(updateBid(bid, { status: "PENDING" }));
-          })
-        );
-        await Promise.all(
-          fulfilledBids.map((bid) => {
-            return dispatch(updateBid(bid, { status: "ACCEPTED" }));
-          })
-        );
-      }
-      await dispatch(updateFavor(favor.id, { status: "OPEN" }));
-      await dispatch(fetchSingleFavor(props.match.params.id));
-    } else {
-      // set the bid(s) with "ACCEPTED" status to status "FULFILLED"
-      // and set all of the bids with "PENDING" status to "REJECTED"
-      if (favor.bids) {
-        let pendingBids = favor.bids.filter((bid) => bid.status === "PENDING");
-        let acceptedBids = favor.bids.filter(
-          (bid) => bid.status === "ACCEPTED"
-        );
-        await Promise.all(
-          pendingBids.map((bid) => {
-            return dispatch(updateBid(bid, { status: "REJECTED" }));
-          })
-        );
-        await Promise.all(
-          acceptedBids.map((bid) => {
-            return dispatch(updateBid(bid, { status: "FULFILLED" }));
-          })
-        );
-      }
-      await dispatch(updateFavor(favor.id, { status: "CLOSED" }));
-      await dispatch(fetchSingleFavor(props.match.params.id));
-    }
-  };
-
   return (
     <div>
       <h1> {favor.title}</h1>
       <br />
       <span> Status: {favor.status === "OPEN" ? "Open" : "Closed"} </span>
       {CurrentUser.id === favor.authorId ? (
-        <button onClick={toggleFavorResolved}>
+        <button onClick={() => toggleFavorResolved(dispatch, favor)}>
           {favor.status === "OPEN" ? "Resolve" : "Reopen"}
         </button>
       ) : (

--- a/client/components/SingleFavorView.js
+++ b/client/components/SingleFavorView.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import CreateBid from "./CreateBid.js";
 import Bid from "./Bid.js";
+import BidsList from "./BidsList.js";
 import { useSelector, useDispatch } from "react-redux";
 import { fetchSingleFavor } from "../store/SingleFavor.js";
 import { updateFavor, updateBid } from "../store/favors";
@@ -46,34 +47,13 @@ const SingleFavor = (props) => {
             ` Pending bid${favor.bids.length > 1 ? "s" : ""}`
           : "Loading"}
       </h2>
+      <BidsList
+        CurrentUser={CurrentUser}
+        favor={favor}
+        bidState={bidState}
+        setBidState={setBidState}
+      />
 
-      {CurrentUser.id === favor.authorId ? (
-        favor.bids.map((bid) => {
-          return <Bid key={bid.id} bid={bid} favor={favor} />;
-        })
-      ) : (
-        <div>
-          {favor.bids ? (
-            favor.bids
-              .filter((bid) => bid.volunteer.id === CurrentUser.id)
-              .map((bid) => {
-                return <Bid key={bid.id} bid={bid} favor={favor} />;
-              })
-          ) : (
-            <div></div>
-          )}
-          <button
-            onClick={() => {
-              setBidState(true);
-            }}
-          >
-            Offer help : {favor.title}
-          </button>
-          <br />
-          <br />
-          {bidState ? <CreateBid favor={favor} /> : <div></div>}
-        </div>
-      )}
       <br />
       <Link to="/favors">
         <button>Back to map view</button>

--- a/client/components/SingleFavorView.js
+++ b/client/components/SingleFavorView.js
@@ -1,26 +1,16 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import CreateBid from "./CreateBid.js";
-import Bid from "./Bid.js";
 import BidsList from "./BidsList.js";
-import { useSelector, useDispatch } from "react-redux";
+import { useDispatch } from "react-redux";
 import { fetchSingleFavor } from "../store/SingleFavor.js";
-import { updateFavor, updateBid } from "../store/favors";
 import useAuth from "./utils/useAuthHook.js";
 import useFavor from "./utils/useFavorHook";
-// experimenting with toggle function in its own module:
 import { toggleFavorResolved } from "./utils/toggleFavorStatus";
 
 const SingleFavor = (props) => {
-  // will use this id (from URL param, from route rendering the component)
-  // to fetch this favor from the database and put it on app state as
-  // THE singleFavor.
-  // then we can use the singleFavor on state to populate this view
   const dispatch = useDispatch();
-  const CurrentUser = useAuth();
-
   const [bidState, setBidState] = useState(false);
-
+  const CurrentUser = useAuth();
   const favor = useFavor();
 
   useEffect(() => {

--- a/client/components/utils/toggleFavorStatus.js
+++ b/client/components/utils/toggleFavorStatus.js
@@ -1,0 +1,47 @@
+import { fetchSingleFavor } from "../../store/SingleFavor.js";
+import { updateFavor, updateBid } from "../../store/favors";
+// NEEDS
+// provide dispatch as an argument at call site
+// favor
+// and import thunks: updateBid, updateFavor, fetchSingleFavor
+export const toggleFavorResolved = async (dispatch, favor) => {
+  if (favor.status === "CLOSED") {
+    if (favor.bids) {
+      let rejectedBids = favor.bids.filter((bid) => bid.status === "REJECTED");
+      let fulfilledBids = favor.bids.filter(
+        (bid) => bid.status === "FULFILLED"
+      );
+      await Promise.all(
+        rejectedBids.map((bid) => {
+          return dispatch(updateBid(bid, { status: "PENDING" }));
+        })
+      );
+      await Promise.all(
+        fulfilledBids.map((bid) => {
+          return dispatch(updateBid(bid, { status: "ACCEPTED" }));
+        })
+      );
+    }
+    await dispatch(updateFavor(favor.id, { status: "OPEN" }));
+    await dispatch(fetchSingleFavor(favor.id));
+  } else {
+    // set the bid(s) with "ACCEPTED" status to status "FULFILLED"
+    // and set all of the bids with "PENDING" status to "REJECTED"
+    if (favor.bids) {
+      let pendingBids = favor.bids.filter((bid) => bid.status === "PENDING");
+      let acceptedBids = favor.bids.filter((bid) => bid.status === "ACCEPTED");
+      await Promise.all(
+        pendingBids.map((bid) => {
+          return dispatch(updateBid(bid, { status: "REJECTED" }));
+        })
+      );
+      await Promise.all(
+        acceptedBids.map((bid) => {
+          return dispatch(updateBid(bid, { status: "FULFILLED" }));
+        })
+      );
+    }
+    await dispatch(updateFavor(favor.id, { status: "CLOSED" }));
+    await dispatch(fetchSingleFavor(favor.id));
+  }
+};

--- a/client/store/favors.js
+++ b/client/store/favors.js
@@ -3,10 +3,9 @@ import axios from "axios";
 //ACTION TYPES  -------------------------------------------
 const SET_FAVORS = "SET_FAVORS";
 const CREATE_FAVOR = "CREATE_FAVOR";
-// INSTEAD DO:
+
 const UPDATED_BID = "UPDATED_BID";
-// AND DELETE THE FOLLOWING LINE 'ACCEPTED_BID':
-// const ACCEPTED_BID = "ACCEPTED_BID";
+
 const CREATED_BID = "CREATED_BID";
 const UPDATED_FAVOR = "UPDATED_FAVOR";
 
@@ -21,17 +20,10 @@ const favorCreate = (favor) => ({
   favor,
 });
 
-// INSTEAD DO
 const updatedTheBid = (bid) => ({
   type: UPDATED_BID,
   bid,
 });
-// AND REMOVE THIS acceptedTheBid BELOW:
-// const acceptedTheBid = (bid, favorId) => ({
-//   type: ACCEPTED_BID,
-//   bid,
-//   theFavorId: favorId,
-// });
 
 const createdABid = (bid) => ({
   type: CREATED_BID,
@@ -63,8 +55,7 @@ export const createFavor = (favor) => {
     }
   };
 };
-// thunk to update bid in DB (to change status from "PENDING" to "ACCEPTED", "REJECTED", "FUFILLED", etc)
-// INSTEAD do this:
+// thunk to update bid in DB (to change status from "PENDING"/"ACCEPTED"/"REJECTED"/"FUFILLED")
 export const updateBid = (bid, bidUpdateObj) => {
   return async (dispatch) => {
     try {
@@ -75,17 +66,7 @@ export const updateBid = (bid, bidUpdateObj) => {
     }
   };
 };
-// INSTEAD DO THE ABOVE ^^
-// export const acceptBid = (bidId, favorId) => {
-//   return async (dispatch) => {
-//     const { data } = await axios.put(`/api/bids/${bidId}`, {
-//       status: "ACCEPTED",
-//     });
-//     dispatch(acceptedTheBid(data, favorId));
-//   };
-// };
 
-// added by tedi Thursday
 // thunk to create a bid in DB and update store
 export const createBid = (newBidObj) => {
   return async (dispatch) => {
@@ -116,7 +97,6 @@ export default function favors(state = [], action) {
       return action.favors;
     case CREATE_FAVOR:
       return [...favors, action.favor];
-    // ___________________________________________
     case UPDATED_BID: {
       let updatedFavorsArray = state.map((favor) => {
         if (favor.id === action.bid.favorId) {
@@ -130,21 +110,6 @@ export default function favors(state = [], action) {
       });
       return updatedFavorsArray;
     }
-    // ___________________________________________
-    // case ACCEPTED_BID: {
-    //   let updatedFavorsArray = state.map((favor) => {
-    //     if (favor.id === action.theFavorId) {
-    //       let updatedBidsArray = favor.bids.map((bid) => {
-    //         if (bid.id === action.bid.id) return action.bid;
-    //         else return bid;
-    //       });
-    //       favor.bids = updatedBidsArray;
-    //       return favor;
-    //     } else return favor;
-    //   });
-    //   return updatedFavorsArray;
-    // }
-
     case CREATED_BID: {
       let updatedFavorsArray = state.map((favor) => {
         if (favor.id === action.bid.favorId) {

--- a/client/store/favors.js
+++ b/client/store/favors.js
@@ -3,8 +3,10 @@ import axios from "axios";
 //ACTION TYPES  -------------------------------------------
 const SET_FAVORS = "SET_FAVORS";
 const CREATE_FAVOR = "CREATE_FAVOR";
-const ACCEPTED_BID = "ACCEPTED_BID";
-// added by tedi Thursday
+// INSTEAD DO:
+const UPDATED_BID = "UPDATED_BID";
+// AND DELETE THE FOLLOWING LINE 'ACCEPTED_BID':
+// const ACCEPTED_BID = "ACCEPTED_BID";
 const CREATED_BID = "CREATED_BID";
 const UPDATED_FAVOR = "UPDATED_FAVOR";
 
@@ -18,17 +20,24 @@ const favorCreate = (favor) => ({
   type: CREATE_FAVOR,
   favor,
 });
-const acceptedTheBid = (bid, favorId) => ({
-  type: ACCEPTED_BID,
+
+// INSTEAD DO
+const updatedTheBid = (bid) => ({
+  type: UPDATED_BID,
   bid,
-  theFavorId: favorId,
 });
-// added by tedi Thursday
+// AND REMOVE THIS acceptedTheBid BELOW:
+// const acceptedTheBid = (bid, favorId) => ({
+//   type: ACCEPTED_BID,
+//   bid,
+//   theFavorId: favorId,
+// });
+
 const createdABid = (bid) => ({
   type: CREATED_BID,
   bid,
 });
-// added by tedi Thursday
+
 const updatedTheFavor = (favor) => ({
   type: UPDATED_FAVOR,
   favor,
@@ -54,15 +63,27 @@ export const createFavor = (favor) => {
     }
   };
 };
-// thunk to update bid status in DB from "PENDING" to "ACCEPTED"
-export const acceptBid = (bidId, favorId) => {
+// thunk to update bid in DB (to change status from "PENDING" to "ACCEPTED", "REJECTED", "FUFILLED", etc)
+// INSTEAD do this:
+export const updateBid = (bid, bidUpdateObj) => {
   return async (dispatch) => {
-    const { data } = await axios.put(`/api/bids/${bidId}`, {
-      status: "ACCEPTED",
-    });
-    dispatch(acceptedTheBid(data, favorId));
+    try {
+      const { data } = await axios.put(`/api/bids/${bid.id}`, bidUpdateObj);
+      dispatch(updatedTheBid(data));
+    } catch (err) {
+      console.log(err);
+    }
   };
 };
+// INSTEAD DO THE ABOVE ^^
+// export const acceptBid = (bidId, favorId) => {
+//   return async (dispatch) => {
+//     const { data } = await axios.put(`/api/bids/${bidId}`, {
+//       status: "ACCEPTED",
+//     });
+//     dispatch(acceptedTheBid(data, favorId));
+//   };
+// };
 
 // added by tedi Thursday
 // thunk to create a bid in DB and update store
@@ -77,7 +98,6 @@ export const createBid = (newBidObj) => {
   };
 };
 
-// added by tedi Thursday
 // thunk to update a favor in the DB and update the store
 export const updateFavor = (favorId, updateObject) => {
   return async (dispatch) => {
@@ -96,9 +116,10 @@ export default function favors(state = [], action) {
       return action.favors;
     case CREATE_FAVOR:
       return [...favors, action.favor];
-    case ACCEPTED_BID: {
+    // ___________________________________________
+    case UPDATED_BID: {
       let updatedFavorsArray = state.map((favor) => {
-        if (favor.id === action.theFavorId) {
+        if (favor.id === action.bid.favorId) {
           let updatedBidsArray = favor.bids.map((bid) => {
             if (bid.id === action.bid.id) return action.bid;
             else return bid;
@@ -109,7 +130,21 @@ export default function favors(state = [], action) {
       });
       return updatedFavorsArray;
     }
-    // added by tedi thursday
+    // ___________________________________________
+    // case ACCEPTED_BID: {
+    //   let updatedFavorsArray = state.map((favor) => {
+    //     if (favor.id === action.theFavorId) {
+    //       let updatedBidsArray = favor.bids.map((bid) => {
+    //         if (bid.id === action.bid.id) return action.bid;
+    //         else return bid;
+    //       });
+    //       favor.bids = updatedBidsArray;
+    //       return favor;
+    //     } else return favor;
+    //   });
+    //   return updatedFavorsArray;
+    // }
+
     case CREATED_BID: {
       let updatedFavorsArray = state.map((favor) => {
         if (favor.id === action.bid.favorId) {

--- a/server/db/models/Bid.js
+++ b/server/db/models/Bid.js
@@ -1,7 +1,7 @@
-const Sequelize = require('sequelize');
-const db = require('../db');
+const Sequelize = require("sequelize");
+const db = require("../db");
 
-const Bid = db.define('bid', {
+const Bid = db.define("bid", {
   // timestamp: {
   //   type: Sequelize.DATE(6), //=> this gets the date and time
   //   allowNull: false,
@@ -17,7 +17,7 @@ const Bid = db.define('bid', {
     },
   },
   status: {
-    type: Sequelize.ENUM("PENDING","ACCEPTED","REJECTED"),
+    type: Sequelize.ENUM("PENDING", "ACCEPTED", "REJECTED", "FULFILLED"),
     defaultValue: "PENDING",
   },
 });


### PR DESCRIPTION
- Now the Resolve/Reopen button that toggles favor status will also toggle the statuses of all of the associated bids. 
(Accepted bids turn 'fulfilled', and all other pending bids turn 'rejected'. And vice versa when reopened).
- Now the Accept button for a bid can also toggle back to pending status
- Added the option 'FULFILLED' to Bid's model (for 'status' attribute)
- Extracted mapped bids list into a BidsList component as child component of SingleFavorView component
- Extracted toggle function into a module in utils folder